### PR TITLE
serialize_amf_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+* Serialize: Add new optional `serialize_amf_type` override to `type` property
+in the case where you want to serialize an object that has a field named `type`.
+
+## [1.0.0] - 2018-04-06
+- First release of this project

--- a/node-amf/serialize.js
+++ b/node-amf/serialize.js
@@ -229,12 +229,13 @@ AMFSerializer.prototype.writeObject = function( value ){
 	// flag with instance, no traits, no externalizable
 	this.writeU29( 11 );
 	// Override object type if present
-	if(value['type'] != null) {
-		this.writeUTF8(value['type']);
-	} else {
-		this.writeUTF8('Object');
-	}
-	// write serializable properties
+  	if(value['serialize_amf_type'] != null) {
+    	  this.writeUTF8(value['serialize_amf_type']);
+  	} else if(value['type'] != null) {
+    	  this.writeUTF8(value['type']);
+  	} else {
+    	  this.writeUTF8('Object');
+  	} // write serializable properties
 	for( var s in value ){
 		if( typeof value[s] !== 'function' ){
 			this.writeUTF8(s);


### PR DESCRIPTION
### Added
* Serialize: Add new optional `serialize_amf_type` override to `type` property
in the case where you want to serialize an object that has a field named `type`.